### PR TITLE
Add mappings for special span tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
 
 ### Kamon Configuration
 The following Kamon configuration is recommended:
-```
+```hocon
 kamon {
   metric {
     # Stackdriver accepts at most a tick every minute
@@ -63,6 +63,21 @@ class MyStackdriverEncoder extends StackdriverEncoder {
 See `reference.conf`. In all cases the `kamon.stackdriver.metric.resource` property has to be updated to reflect for what resource
 you're collecting metrics.
 
+## Tracing labels mappings
+
+Stackdriver tracing treats some the labels specially, a mapping can be set in the configuration. Default mappings are shown below. 
+More information you can find in [Google Stackdriver TraceSpan](https://cloud.google.com/trace/docs/reference/v1/rest/v1/projects.traces#TraceSpan) documentation.
+
+```hocon
+kamon.stackdrvier.span {
+  tags {
+    mappings {
+      "http.method" = "/http/method"
+      "http.status_code" = "/http/status_code"
+    }
+  }
+}
+```
 
 ## License
 

--- a/kamon-stackdriver/src/main/resources/reference.conf
+++ b/kamon-stackdriver/src/main/resources/reference.conf
@@ -1,11 +1,5 @@
 kamon {
   stackdriver {
-    tags {
-      mappings {
-        "http.method" = "/http/method"
-        "http.status_code" = "/http/status_code"
-      }
-    }
     auth {
       # How to authenticate with Google APIs. Possible values:
       # - "application-default": use a method called default authentication. Recommended when running on Compute
@@ -40,6 +34,12 @@ kamon {
     span {
       google-project-id = ""
       skip-operation-names = []
+      tags {
+        mappings {
+          "http.method" = "/http/method"
+          "http.status_code" = "/http/status_code"
+        }
+      }
     }
   }
 

--- a/kamon-stackdriver/src/main/resources/reference.conf
+++ b/kamon-stackdriver/src/main/resources/reference.conf
@@ -1,5 +1,11 @@
 kamon {
   stackdriver {
+    tags {
+      mappings {
+        "http.method" = "/http/method"
+        "http.status_code" = "/http/status_code"
+      }
+    }
     auth {
       # How to authenticate with Google APIs. Possible values:
       # - "application-default": use a method called default authentication. Recommended when running on Compute

--- a/kamon-stackdriver/src/main/scala/kamon/stackdriver/StackdriverSpanReporter.scala
+++ b/kamon-stackdriver/src/main/scala/kamon/stackdriver/StackdriverSpanReporter.scala
@@ -24,6 +24,7 @@ class StackdriverSpanReporter extends SpanReporter {
   private var client: TraceServiceClient      = _
   private var projectName: String             = _
   private var skipOperationNames: Set[String] = Set.empty
+  private var mappings: Map[String, String]   = Map.empty
 
   def reportSpans(kamonSpans: Seq[FinishedSpan]): Unit = {
     val spans =
@@ -42,6 +43,7 @@ class StackdriverSpanReporter extends SpanReporter {
     projectId = Option(config.getString("span.google-project-id")).filter(_.nonEmpty).getOrElse(ServiceOptions.getDefaultProjectId)
     skipOperationNames = config.getStringList("span.skip-operation-names").asScala.toSet
     projectName = ProjectName.of(projectId).toString
+    mappings = config.getObject("tags.mappings").unwrapped().asScala.mapValues(_.toString).toMap.withDefault(identity)
 
     val credentialsProvider = CredentialsProviderFactory.fromConfig(config)
 
@@ -89,13 +91,13 @@ class StackdriverSpanReporter extends SpanReporter {
   private def tagsToLabels(tags: Map[String, TagValue]): Map[String, AttributeValue] =
     tags.map {
       case (key, TagValue.True) =>
-        (key, AttributeValue.newBuilder().setBoolValue(true).build())
+        (mappings(key), AttributeValue.newBuilder().setBoolValue(true).build())
       case (key, TagValue.False) =>
-        (key, AttributeValue.newBuilder().setBoolValue(false).build())
+        (mappings(key), AttributeValue.newBuilder().setBoolValue(false).build())
       case (key, value: TagValue.Number) =>
-        (key, AttributeValue.newBuilder().setIntValue(value.number).build())
+        (mappings(key), AttributeValue.newBuilder().setIntValue(value.number).build())
       case (key, value: TagValue.String) =>
-        (key, AttributeValue.newBuilder().setStringValue(TruncatableString.newBuilder().setValue(value.string)).build())
+        (mappings(key), AttributeValue.newBuilder().setStringValue(TruncatableString.newBuilder().setValue(value.string)).build())
     }
 
   def start(): Unit =

--- a/kamon-stackdriver/src/main/scala/kamon/stackdriver/StackdriverSpanReporter.scala
+++ b/kamon-stackdriver/src/main/scala/kamon/stackdriver/StackdriverSpanReporter.scala
@@ -43,7 +43,7 @@ class StackdriverSpanReporter extends SpanReporter {
     projectId = Option(config.getString("span.google-project-id")).filter(_.nonEmpty).getOrElse(ServiceOptions.getDefaultProjectId)
     skipOperationNames = config.getStringList("span.skip-operation-names").asScala.toSet
     projectName = ProjectName.of(projectId).toString
-    mappings = config.getObject("tags.mappings").unwrapped().asScala.mapValues(_.toString).toMap.withDefault(identity)
+    mappings = config.getObject("span.tags.mappings").unwrapped().asScala.mapValues(_.toString).toMap.withDefault(identity)
 
     val credentialsProvider = CredentialsProviderFactory.fromConfig(config)
 


### PR DESCRIPTION
Some tags in tracing are treated specially. To use filtering by `status_code` and `method` Stackdriver expect `/http/status_code` and `/http/method` labels.
![image](https://user-images.githubusercontent.com/6121477/62617828-14715680-b913-11e9-906c-c1afcc7c1d0f.png)
When Stackdriver recognises those tags it put the values in the details section. 
![image](https://user-images.githubusercontent.com/6121477/62617955-5bf7e280-b913-11e9-9cf1-ab0129432432.png)
Otherwise, you will see them in the section bellow
![image](https://user-images.githubusercontent.com/6121477/62618033-8ba6ea80-b913-11e9-8330-a84f972d6295.png)
This is why we need mappings for those values inside the `StackdriverSpanReporter`