### PR TITLE
Propagate to log values from MDC

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,13 @@
-val kamon               = "io.kamon" %% "kamon-core" % "2.0.5"
-val kamonTestKit        = "io.kamon" %% "kamon-testkit" % "2.0.5"
-val kamonLogback        = "io.kamon" %% "kamon-logback" % "2.0.2"
-val kanela              = "io.kamon" % "kanela-agent" % "1.0.5"
-val googleCloudCore     = "com.google.cloud" % "google-cloud-core" % "1.93.3"
-val googleMonitoring    = "com.google.cloud" % "google-cloud-monitoring" % "1.99.2"
-val googleTracing       = "com.google.cloud" % "google-cloud-trace" % "1.0.2"
-val sprayJson           = "io.spray" %% "spray-json" % "1.3.5"
-val scalatest           = "org.scalatest" %% "scalatest" % "3.1.1"
+val kamon            = "io.kamon"         %% "kamon-core"             % "2.0.5"
+val kamonTestKit     = "io.kamon"         %% "kamon-testkit"          % "2.0.5"
+val kamonLogback     = "io.kamon"         %% "kamon-logback"          % "2.0.2"
+val kanela           = "io.kamon"         % "kanela-agent"            % "1.0.5"
+val googleCloudCore  = "com.google.cloud" % "google-cloud-core"       % "1.93.3"
+val googleMonitoring = "com.google.cloud" % "google-cloud-monitoring" % "1.99.2"
+val googleTracing    = "com.google.cloud" % "google-cloud-trace"      % "1.0.2"
+val sprayJson        = "io.spray"         %% "spray-json"             % "1.3.5"
+val scalatest        = "org.scalatest"    %% "scalatest"              % "3.1.1"
+
 val defaultScalaVersion = "2.13.1"
 
 lazy val `kamon-stackdriver-root` = (project in file("."))

--- a/kamon-logback-stackdriver/src/test/resources/application.conf
+++ b/kamon-logback-stackdriver/src/test/resources/application.conf
@@ -1,0 +1,17 @@
+kamon {
+  trace {
+    # Make the identifiers compatible with what Stackdriver Trace expects.
+    identifier-scheme = double
+  }
+}
+kanela {
+  show-banner = false
+}
+
+kamon.instrumentation.logback {
+  mdc {
+    copy {
+      entries = ["context_entry"]
+    }
+  }
+}

--- a/kamon-logback-stackdriver/src/test/resources/logback-test.xml
+++ b/kamon-logback-stackdriver/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration debug="false">
+
+    <appender name="STDOUT" class="kamon.stackdriver.RecordingAppender">
+        <encoder class="kamon.stackdriver.ExtraStackdriverEncoder"/>
+    </appender>
+
+    <root level="TRACE">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/kamon-logback-stackdriver/src/test/scala/kamon/stackdriver/ExtraStackdriverEncoder.scala
+++ b/kamon-logback-stackdriver/src/test/scala/kamon/stackdriver/ExtraStackdriverEncoder.scala
@@ -1,0 +1,8 @@
+package kamon.stackdriver
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+
+class ExtraStackdriverEncoder extends StackdriverEncoder {
+  override protected def extraData(event: ILoggingEvent): Map[String, String] =
+    Map("extra_field" -> "extra_field_value")
+}

--- a/kamon-logback-stackdriver/src/test/scala/kamon/stackdriver/RecordingAppender.scala
+++ b/kamon-logback-stackdriver/src/test/scala/kamon/stackdriver/RecordingAppender.scala
@@ -1,0 +1,16 @@
+package kamon.stackdriver
+
+import java.nio.charset.Charset
+
+import ch.qos.logback.classic.spi.LoggingEvent
+import ch.qos.logback.core.ConsoleAppender
+
+class RecordingAppender extends ConsoleAppender[LoggingEvent] {
+  override def append(loggingEvent: LoggingEvent): Unit =
+    RecordingAppender.logged = new String(encoder.encode(loggingEvent), Charset.forName("utf8")) :: RecordingAppender.logged
+}
+
+object RecordingAppender {
+  @transient
+  var logged: List[String] = List.empty
+}

--- a/kamon-logback-stackdriver/src/test/scala/kamon/stackdriver/StackdriverEncoderTest.scala
+++ b/kamon-logback-stackdriver/src/test/scala/kamon/stackdriver/StackdriverEncoderTest.scala
@@ -3,47 +3,65 @@ package kamon.stackdriver
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.spi.{ILoggingEvent, LoggingEvent}
 import kamon.Kamon
-import org.scalatest.{FlatSpec, Matchers}
-import org.slf4j.LoggerFactory
+import kamon.context.Context
+import kamon.tag.TagSet
+import kamon.trace.Trace.SamplingDecision
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.{Logger, LoggerFactory}
 import spray.json.DefaultJsonProtocol._
 import spray.json._
-import kamon.trace.Trace.SamplingDecision
 
-class StackdriverEncoderTest extends FlatSpec with Matchers {
+class StackdriverEncoderTest extends AnyFlatSpec with Matchers {
 
-  val encoder = new StackdriverEncoder {
-    override protected def extraData(event: ILoggingEvent): Map[String, String] =
-      Map("foo" -> "bar")
-  }
+  Kamon.init()
+
+  val logger: Logger = LoggerFactory.getLogger(classOf[StackdriverEncoderTest])
 
   it should "format correctly log as json" in {
 
-    val span = Kamon.spanBuilder("operation").samplingDecision(SamplingDecision.Sample).start()
-    val event: ILoggingEvent = Kamon.runWithSpan(span, finishSpan = true) {
-      new LoggingEvent(
-        getClass.getName,
-        LoggerFactory.getLogger(classOf[StackdriverEncoderTest]).asInstanceOf[ch.qos.logback.classic.Logger],
-        Level.INFO,
-        "This is a message {}",
-        new Exception("kaboom"),
-        Array("bar")
-      )
-    }
-    val str    = new String(encoder.encode(event))
-    val json   = str.parseJson.asJsObject
-    val fields = json.fields
+    val contextEntry = Context.key("context_entry", "default_context_entry_value")
 
-    withClue(json.prettyPrint) {
-      fields("logging.googleapis.com/sourceLocation") shouldBe a[JsObject]
-      fields("logging.googleapis.com/sourceLocation").asJsObject.fields.keySet shouldBe Set("file", "function", "line")
-      fields("logging.googleapis.com/spanId").convertTo[String] shouldBe span.id.string
-      fields("logging.googleapis.com/trace").convertTo[String] should endWith(span.trace.id.string)
-      fields("message").convertTo[String] should not be empty
-      fields("severity").convertTo[String] shouldBe "INFO"
-      fields("timestamp") shouldBe a[JsObject]
-      fields("timestamp").asJsObject.fields.keySet shouldBe Set("seconds", "nanos")
-    }
+    Kamon.runWithContextEntry(contextEntry, "context_entry_value") { // needs kamon.instrumentation.logback.mdc.copy.entries = ["context_entry"]
+      Kamon.runWithContextTag("context_tag", "context_tag_value") {
 
+        val span = Kamon.spanBuilder("operation").samplingDecision(SamplingDecision.Sample).start()
+        Kamon.runWithSpan(span) {
+          logger.info("This is a message: {}", "argument_value", new Exception("kaboom"))
+        }
+
+        val str = RecordingAppender.logged.head
+
+        val json   = str.parseJson.asJsObject
+        val fields = json.fields
+
+        withClue(json.prettyPrint) {
+          fields("logging.googleapis.com/sourceLocation") shouldBe a[JsObject]
+          fields("logging.googleapis.com/sourceLocation").asJsObject.fields.keySet shouldBe Set("file", "function", "line")
+          fields("logging.googleapis.com/sourceLocation").asJsObject.fields("file").convertTo[String] shouldBe "kamon/stackdriver/StackdriverEncoderTest.scala"
+          fields("logging.googleapis.com/spanId").convertTo[String] shouldBe span.id.string
+          fields("logging.googleapis.com/trace").convertTo[String] should endWith(span.trace.id.string)
+          fields("message").convertTo[String] should not be empty
+          fields("message").convertTo[String] should startWith("This is a message: argument_value")
+          fields("severity").convertTo[String] shouldBe "INFO"
+          fields("timestamp") shouldBe a[JsObject]
+          fields("timestamp").asJsObject.fields.keySet shouldBe Set("seconds", "nanos")
+
+          //Available in MDC, but can be skipped as are provided in Stackdriver compatible way
+          fields.keys should not contain ("kamonSpanId")
+          fields.keys should not contain ("kamonTraceId")
+
+          //Fields provided from StackdriverEncoder.extraData
+          fields("extra_field").convertTo[String] shouldBe "extra_field_value"
+
+          //Context entries provided as MDC and configured in kamon.instrumentation.logback.mdc.copy.entries = ["context_entry"]
+          fields("context_entry").convertTo[String] shouldBe "context_entry_value"
+
+          //Context tagx provided as MDC
+          fields("context_tag").convertTo[String] shouldBe "context_tag_value"
+        }
+      }
+    }
   }
 
 }

--- a/kamon-logback-stackdriver/src/test/scala/kamon/stackdriver/StackdriverEncoderTest.scala
+++ b/kamon-logback-stackdriver/src/test/scala/kamon/stackdriver/StackdriverEncoderTest.scala
@@ -20,14 +20,14 @@ class StackdriverEncoderTest extends AnyFlatSpec with Matchers {
 
   it should "format correctly log as json" in {
 
-    val contextEntry = Context.key("context_entry", "default_context_entry_value")
+    val contextEntry = Context.key[String]("context_entry", "default_context_entry_value")
 
     Kamon.runWithContextEntry(contextEntry, "context_entry_value") { // needs kamon.instrumentation.logback.mdc.copy.entries = ["context_entry"]
       Kamon.runWithContextTag("context_tag", "context_tag_value") {
 
         val span = Kamon.spanBuilder("operation").samplingDecision(SamplingDecision.Sample).start()
         Kamon.runWithSpan(span) {
-          logger.info("This is a message: {}", "argument_value", new Exception("kaboom"))
+          logger.info("This is a message: {}", "argument_value", new Exception("kaboom"): Any)
         }
 
         val str = RecordingAppender.logged.head

--- a/kamon-stackdriver/src/it/resources/application.conf
+++ b/kamon-stackdriver/src/it/resources/application.conf
@@ -28,3 +28,6 @@ kamon {
     }
   }
 }
+kanela {
+  show-banner = false
+}


### PR DESCRIPTION
To propagate Context.Key values they need to be configured in `.conf` file:

```
kamon.instrumentation.logback.mdc.copy.entries = ["context_entry"]
```

It works automatically for Context tags.